### PR TITLE
Adding a new API call for getting Total Energy Consumption per capita

### DIFF
--- a/client/app/services/resourceService/resourceService.service.js
+++ b/client/app/services/resourceService/resourceService.service.js
@@ -12,6 +12,7 @@ angular.module('epaRfiApp')
       getResourceList: getResourceList,
       getResource: getResource,
       getAllResourcesForState: getAllResourcesForState,
+      getTotalResourcesForState: getTotalResourcesForState,
       getBtuForYear: getBtuForYear
     };
 
@@ -73,6 +74,28 @@ angular.module('epaRfiApp')
       };
 
       return $http.get("/api/resources/all", config).catch(function(error) {
+        console.log('error', error);
+      });
+    }
+
+    /**
+     * @param  {String} - State (i.e. Alabama, California, Rhode Island)
+     * @param  {Number} - Year, Optional
+     * @param  {Format} - Format Type ('capita'), Optional
+     * @return {Object} - Object representing the data requested from the API
+     */
+    function getTotalResourcesForState(state, year, format) {
+      var queryParams = {
+        'state': state,
+        'year': year,
+        'format': format
+      };
+      var config = {
+        cache: true,
+        params: queryParams
+      };
+
+      return $http.get("/api/resources/total", config).catch(function(error) {
         console.log('error', error);
       });
     }

--- a/client/app/views/nation/nation.controller.js
+++ b/client/app/views/nation/nation.controller.js
@@ -15,10 +15,10 @@ angular.module('epaRfiApp')
 	  function init() {
 	    resourceService.getAllResourcesForState('United States', 2013, 'capita').then(function(response) {
 	      vm.resourceData = response.data;
-	      vm.btuTotal = _.sum(response.data, function(resource) {
-	        return resource.usage;
-	      });
 	      vm.d3api.refresh();
+	    });
+	    resourceService.getTotalResourcesForState('United States', 2013, 'capita').then(function(response) {
+	    	vm.btuTotal = response.data.usage;
 	    });
 	  }
 

--- a/client/app/views/nation/nation.html
+++ b/client/app/views/nation/nation.html
@@ -9,7 +9,7 @@
   <div class="row">
     <div class="col-xs-10 col-xs-offset-1">
       <div class="hero-type">
-       In 2013, each person in the US used <br/> <strong>{{ NationCtrl.btuTotal | number }} </strong> BTUs of these resources.
+       In 2013, each person in the US used <br/> <strong>{{ NationCtrl.btuTotal | number }} </strong> BTUs of all energy resources.
       </div>
     </div>
   </div>

--- a/server/api/resource/resource.controller.js
+++ b/server/api/resource/resource.controller.js
@@ -46,6 +46,12 @@ resourceApi.index = function index(req, res) {
   var year = validateYear(yearQuery);
   var format = validateFormat(formatQuery);
 
+  if(resourceParam === 'total' && state && year && format) {
+    return Resource.getTotalResourceByYearCapita(state, year)
+      .then(responseWithResult(res))
+      .catch(handleError(res));
+  }
+
   // api/resources/all?state=Alabama&year=2013&format=capita
   if(resourceParam === 'all' && state && year && format) {
     return Resource.getAllResourcesByYearCapita(state, year)


### PR DESCRIPTION
The per capita for total energy can be called like so: http://localhost:9000/api/resources/total?state=United States&year=1960&format=capita

This represents the total energy consumption per capita in the given year.
